### PR TITLE
Add gulp-uglify devDependency to fix `gulp` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^1.5.1",
     "gulp-uglifycss": "^1.0.4"
   }
 }


### PR DESCRIPTION
Running `gulp` after cloning the repo and installing dependencies via npm and bower was throwing an npm error:
> Error: Cannot find module 'gulp-uglify' 