### PR TITLE
Add/dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ you throw at it.
 Returns the original GeoJSON of the features that are currently being displayed
 on the map.
 
+## Contributing
+
+To get the project running locally, clone this repo and run these commands
+within the project folder:
+```
+npm install
+gulp start
+```
+Open your browser to http://localhost:8000/examples/borders.html or http://localhost:8000/examples/earthquakes.html
+
+The page will reload whenever file changes are made, so you can use the examples to test the changes you want to contribute to the project.
+
+Please create a pull request from your fork of the project, and provide details of the intent of the changes.
+
 ## Change log
 
 ### 0.4.3

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var sass = require('gulp-sass');
 var uglify = require('gulp-uglify');
 var uglifycss = require('gulp-uglifycss');
 var rename = require('gulp-rename');
+var webserver = require('gulp-webserver');
 
 gulp.task('sass', function() {
   return gulp.src('src/*.sass')
@@ -38,6 +39,20 @@ gulp.task('js-min', function() {
     .pipe(gulp.dest('dist'))
 });
 
+gulp.task('webserver', function() {
+  return gulp.src('.')
+    .pipe(webserver({
+      livereload: true
+    }))
+});
+
+gulp.task('watch', function() {
+  gulp.watch('src/*.coffee', ['js'])
+  gulp.watch('src/*.sass', ['sass'])
+})
+
 gulp.task('default', ['sass', 'js']);
 
 gulp.task('min-build', ['sass-min', 'js-min']);
+
+gulp.task('start', ['default', 'webserver', 'watch']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Show GeoJSON objects on a timeline",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "gulp min-build"
+    "prepublish": "gulp min-build",
+    "postinstall": "bower install"
   },
   "main": "dist/leaflet.timeline.min.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-sass": "^2.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
-    "gulp-uglifycss": "^1.0.4"
+    "gulp-uglifycss": "^1.0.4",
+    "gulp-webserver": "^0.9.1"
   }
 }


### PR DESCRIPTION
This adds some basic installation and contribution guidelines.

Also adds livereload server (`gulp start`) which watches changes to the project and rebuilds the non-minified dist files so that changes to src files will show immediately in the example pages.

Please treat this PR as work in progress @skeate, I'm happy to make any changes you recommend.