### PR TITLE
cleanup document events on remove

### DIFF
--- a/test/TimeSliderControl_test.js
+++ b/test/TimeSliderControl_test.js
@@ -324,7 +324,7 @@ describe('TimeSliderControl', () => {
       const control = L.timelineSliderControl();
       control.addTo(map);
       const slider = document.getElementsByClassName('time-slider')[0];
-      L.DomEvent.on.should.have.have.been.calledWith(document, 'pointerup mouseup touchend');
+      L.DomEvent.on.should.have.been.calledWith(document, 'pointerup mouseup touchend');
       L.DomEvent.on.restore();
     });
 
@@ -333,7 +333,7 @@ describe('TimeSliderControl', () => {
       const control = L.timelineSliderControl();
       control.addTo(map);
       control.remove();
-      L.DomEvent.off.should.have.have.been.calledWith(document, 'pointerup mouseup touchend');
+      L.DomEvent.off.should.have.been.calledWith(document, 'pointerup mouseup touchend');
       L.DomEvent.off.restore();
     });
 

--- a/test/TimeSliderControl_test.js
+++ b/test/TimeSliderControl_test.js
@@ -317,4 +317,33 @@ describe('TimeSliderControl', () => {
       }, 200);
     });
   });
+
+  describe('events', () => {
+    it('should register document events when added', () => {
+      sinon.spy(L.DomEvent, 'on');
+      const control = L.timelineSliderControl();
+      control.addTo(map);
+      const slider = document.getElementsByClassName('time-slider')[0];
+      L.DomEvent.on.should.have.have.been.calledWith(document, 'pointerup mouseup touchend');
+      L.DomEvent.on.restore();
+    });
+
+    it('should deregister document events when removed', () => {
+      sinon.spy(L.DomEvent, 'off');
+      const control = L.timelineSliderControl();
+      control.addTo(map);
+      control.remove();
+      L.DomEvent.off.should.have.have.been.calledWith(document, 'pointerup mouseup touchend');
+      L.DomEvent.off.restore();
+    });
+
+    it('should enable dragging when removed', () => {
+      sinon.spy(map.dragging, 'enable');
+      const control = L.timelineSliderControl();
+      control.addTo(map);
+      control.remove();
+      map.dragging.enable.should.have.been.called;
+      map.dragging.enable.restore();
+    });
+  });
 });


### PR DESCRIPTION
Aggressive cleanup of event handlers in TimelineSliderControl

Prevents orphan events from being left attached to the document if control is removed.
Enables draggable in map if removed while disabled.