### PR TITLE
Added check for key down target to not allow it if target is input or…

### DIFF
--- a/src/TimelineSliderControl.ts
+++ b/src/TimelineSliderControl.ts
@@ -468,20 +468,23 @@ L.TimelineSliderControl = L.Control.extend({
   },
 
   _onKeydown(e) {
-    switch (e.keyCode || e.which) {
-      case 37:
-        this.prev();
-        break;
-      case 39:
-        this.next();
-        break;
-      case 32:
-        this.toggle();
-        break;
-      default:
-        return;
+    let target = (e.target || e.srcElement) as HTMLElement;
+    if ( !/INPUT|TEXTAREA/.test(target.tagName) ) {
+      switch (e.keyCode || e.which) {
+        case 37:
+          this.prev();
+          break;
+        case 39:
+          this.next();
+          break;
+        case 32:
+          this.toggle();
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
     }
-    e.preventDefault();
   },
 
   _sliderChanged(e) {


### PR DESCRIPTION
… textarea.

We added the timeline to this site https://oregontheaterproject.uoregon.edu/ as a region on the homepage. We enabled the keyboard controls but noticed that when using the site search we couldn't enter a space because it triggered the timeline autoplay.

The changes in this pull request are one way to fix it (got the idea from https://stackoverflow.com/a/2167725) but I am open to alternate suggestions.