### PR TITLE
No longer fail first prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.2",
   "description": "Show GeoJSON objects on a timeline",
   "scripts": {
-    "prebuild": "[ -d dist ] && rm -rf dist",
+    "prebuild": "if [ -d dist ]; then rm -rf dist; fi",
     "build": "tsc && webpack",
     "postbuild": "cp dist/leaflet.timeline.js docs/examples/leaflet.timeline.js",
     "test": "jest",


### PR DESCRIPTION
The first `npm run build` would not have the `dist/` directory, so prebuild would fail, as the test did not succeed.

Now, this never returns false.

(Optionally, one might consider to just `rm -rf dist`, but I wanted to stay as close to the existing logic.)